### PR TITLE
Fix Auth for Android

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -82,6 +82,7 @@
     <plugin name="cordova-plugin-ionic-keyboard" spec="2.0.5" />
     <plugin name="cordova-plugin-network-information" spec="2.0.1" />
     <plugin name="cordova-plugin-ionic-webview" spec="^2.3.1" />
+    <plugin name="cordova-plugin-inappbrowser" spec="3.0.0" />
     <engine name="ios" spec="4.5.5" />
     <engine name="android" spec="7.1.4" />
 </widget>

--- a/package.json
+++ b/package.json
@@ -25,24 +25,25 @@
     "@angular/platform-browser-dynamic": "^7.2.2",
     "@angular/router": "^7.2.2",
     "@ionic-native/core": "^5.0.0",
+    "@ionic-native/ionic-webview": "5.0.0",
     "@ionic-native/splash-screen": "^5.0.0",
     "@ionic-native/status-bar": "^5.0.0",
     "@ionic/angular": "^4.0.0",
-    "@ionic-native/ionic-webview": "5.0.0",
-    "core-js": "^2.5.3",
-    "rxjs": "~6.3.3",
-    "zone.js": "~0.8.29",
     "cordova-android": "7.1.4",
     "cordova-ios": "4.5.5",
     "cordova-plugin-device": "^2.0.2",
+    "cordova-plugin-inappbrowser": "3.0.0",
     "cordova-plugin-ionic-keyboard": "^2.0.5",
-    "cordova-plugin-ionic-webview": "^2.3.1",
-    "cordova-plugin-network-information": "2.0.1",
+    "cordova-plugin-ionic-webview": "^2.3.2",
+    "cordova-plugin-network-information": "^2.0.1",
     "cordova-plugin-splashscreen": "^5.0.2",
     "cordova-plugin-whitelist": "^1.3.3",
+    "core-js": "^2.5.3",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.10.0",
-    "subscriptions-transport-ws": "^0.9.15"
+    "rxjs": "~6.3.3",
+    "subscriptions-transport-ws": "^0.9.15",
+    "zone.js": "~0.8.29"
   },
   "devDependencies": {
     "@angular-devkit/architect": "~0.12.3",
@@ -69,5 +70,22 @@
     "ts-node": "~8.0.0",
     "tslint": "~5.12.0",
     "typescript": "~3.1.6"
+  },
+  "cordova": {
+    "plugins": {
+      "cordova-plugin-inappbrowser": {},
+      "cordova-plugin-whitelist": {},
+      "cordova-plugin-device": {},
+      "cordova-plugin-splashscreen": {},
+      "cordova-plugin-ionic-keyboard": {},
+      "cordova-plugin-network-information": {},
+      "cordova-plugin-ionic-webview": {
+        "ANDROID_SUPPORT_ANNOTATIONS_VERSION": "27.+"
+      }
+    },
+    "platforms": [
+      "ios",
+      "android"
+    ]
   }
 }


### PR DESCRIPTION
## Related issues:

* [AEROGEAR-8431](https://issues.jboss.org/browse/AEROGEAR-8431) - Ionic Example App does not start on Android when keycloak is used

## How to test

1. Run the server (Instructions on [README](https://github.com/aerogear/voyager-ionic-example/blob/development/README.md#running-the-server))
1. Update the GraphQL ip (probably your machine ip) in [src/app/services/voyager.service.ts](https://github.com/aerogear/voyager-ionic-example/blob/development/src/app/services/voyager.service.ts#L68-L69)
1. Add the Identity manager service info in [mobile-services.js](https://github.com/aerogear/voyager-ionic-example/blob/development/src/mobile-services.js)
   ```json
   {
      "id": "<YOUR PROJECT ID>",
      "name": "keycloak",
      "type": "keycloak",
      "url": "<KEYCLOAK URL>",
      "config": {
        "auth-server-url": "<KEYCLOAK URL>",
        "confidential-port": 0,
        "public-client": true,
        "realm": "<KEYCLOAK REALM>",
        "resource": "<KEYCLOAK CLIENT>",
        "ssl-required": "external"
      }
    }
   ```
1. Run the app 
    `npm run ionic:android`

